### PR TITLE
fix: add CNAME so Pages custom domain survives Actions deploys

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+ambershen.world


### PR DESCRIPTION
Without public/CNAME, each actions/deploy-pages run replaces the served
content with dist/, which can clear the custom domain configured via the
GitHub Pages UI and leave ambershen.world unreachable for some users.

https://claude.ai/code/session_01NEzTPghDVki2nKGUE7H8R1